### PR TITLE
Release/2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ See [PID Rule Book](https://github.com/eu-digital-identity-wallet/eudi-doc-archi
 
 ## Changelog
 
+Release 2.1.0:
+ - Update to `vclib` 3.8.0
+
+Release 2.0.2:
+ - Update to `vclib` 3.7.0
+ - Koltin 2.0.0
+
 Release 2.0.1:
  - Fix publishing, re-releasing 2.0.0
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ See [PID Rule Book](https://github.com/eu-digital-identity-wallet/eudi-doc-archi
 
 ## Changelog
 
+Release 2.1.1:
+ - Fix required claim names in `EuPidScheme` to contain `age_over_18` and `issuing_country`
+
 Release 2.1.0:
  - Update to `vclib` 3.8.0
  - Use correct namespace, doc type and SD-JWT type

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ See [PID Rule Book](https://github.com/eu-digital-identity-wallet/eudi-doc-archi
 
 Release 2.1.0:
  - Update to `vclib` 3.8.0
+ - Use correct namespace, doc type and SD-JWT type
 
 Release 2.0.2:
  - Update to `vclib` 3.7.0

--- a/eupidcredential/build.gradle.kts
+++ b/eupidcredential/build.gradle.kts
@@ -25,8 +25,7 @@ kotlin {
         commonMain {
             dependencies {
                 api(serialization("json"))
-                api(serialization("cbor")) //workaround until everything's up to date
-                api("at.asitplus.wallet:vclib:4.0.0-SNAPSHOT")
+                api("at.asitplus.wallet:vclib:3.8.0")
             }
         }
     }
@@ -85,6 +84,11 @@ publishing {
             signing.isRequired = false
         }
     }
+}
+
+repositories {
+    maven(url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+    mavenCentral()
 }
 
 signing {

--- a/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidScheme.kt
+++ b/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidScheme.kt
@@ -1,6 +1,7 @@
 package at.asitplus.wallet.eupid
 
 import at.asitplus.wallet.lib.data.ConstantIndex
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.*
 import at.asitplus.wallet.lib.data.SchemaIndex
 
 
@@ -13,6 +14,9 @@ object EuPidScheme : ConstantIndex.CredentialScheme {
     override val isoNamespace: String = "eu.europa.ec.eudi.pid.1"
     override val isoDocType: String = "eu.europa.ec.eudi.pid.1"
     override val sdJwtType: String = "urn:eu.europa.ec.eudi:pid:1"
+    override val supportedRepresentations: Collection<ConstantIndex.CredentialRepresentation> =
+        listOf(PLAIN_JWT, SD_JWT, ISO_MDOC)
+
     override val claimNames: Collection<String> = listOf(
         Attributes.FAMILY_NAME,
         Attributes.GIVEN_NAME,
@@ -52,10 +56,11 @@ object EuPidScheme : ConstantIndex.CredentialScheme {
         Attributes.FAMILY_NAME,
         Attributes.GIVEN_NAME,
         Attributes.BIRTH_DATE,
+        Attributes.AGE_OVER_18,
         Attributes.ISSUANCE_DATE,
         Attributes.EXPIRY_DATE,
         Attributes.ISSUING_AUTHORITY,
-        Attributes.ISSUING_JURISDICTION,
+        Attributes.ISSUING_COUNTRY,
     )
 
     object Attributes {

--- a/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidScheme.kt
+++ b/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidScheme.kt
@@ -92,4 +92,42 @@ object EuPidScheme : ConstantIndex.CredentialScheme {
         const val ISSUING_COUNTRY = "issuing_country"
         const val ISSUING_JURISDICTION = "issuing_jurisdiction"
     }
+
+    /**
+     * Maps names from [Attributes] to claim names used in SD-JWT
+     */
+    val claimNameMap = mapOf(
+        Attributes.FAMILY_NAME to Attributes.FAMILY_NAME,
+        Attributes.GIVEN_NAME to Attributes.GIVEN_NAME,
+        Attributes.BIRTH_DATE to "birthdate",
+
+        Attributes.AGE_OVER_18 to "age_equal_or_over/18",
+        Attributes.AGE_IN_YEARS to Attributes.AGE_IN_YEARS,
+        Attributes.AGE_BIRTH_YEAR to Attributes.AGE_BIRTH_YEAR,
+        Attributes.FAMILY_NAME_BIRTH to "birth_family_name",
+        Attributes.GIVEN_NAME_BIRTH to "birth_given_name",
+        Attributes.BIRTH_PLACE to "place_of_birth/locality",
+        Attributes.BIRTH_COUNTRY to "place_of_birth/country",
+        Attributes.BIRTH_STATE to "place_of_birth/region",
+        Attributes.BIRTH_CITY to "place_of_birth/locality",
+
+        Attributes.RESIDENT_ADDRESS to "address/formatted",
+        Attributes.RESIDENT_COUNTRY to "address/country",
+        Attributes.RESIDENT_STATE to "address/region",
+        Attributes.RESIDENT_CITY to "address/locality",
+        Attributes.RESIDENT_POSTAL_CODE to "address/postal_code",
+        Attributes.RESIDENT_STREET to "address/street_address",
+        Attributes.RESIDENT_HOUSE_NUMBER to "address/house_number",
+
+        Attributes.GENDER to Attributes.GENDER,
+        Attributes.NATIONALITY to "nationalities",
+
+        Attributes.ISSUANCE_DATE to "iat",
+        Attributes.EXPIRY_DATE to "exp",
+        Attributes.ISSUING_AUTHORITY to Attributes.ISSUING_AUTHORITY,
+        Attributes.DOCUMENT_NUMBER to Attributes.DOCUMENT_NUMBER,
+        Attributes.ADMINISTRATIVE_NUMBER to Attributes.ADMINISTRATIVE_NUMBER,
+        Attributes.ISSUING_COUNTRY to Attributes.ISSUING_COUNTRY,
+        Attributes.ISSUING_JURISDICTION to Attributes.ISSUING_JURISDICTION,
+    )
 }

--- a/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidScheme.kt
+++ b/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidScheme.kt
@@ -10,8 +10,9 @@ import at.asitplus.wallet.lib.data.SchemaIndex
 object EuPidScheme : ConstantIndex.CredentialScheme {
     override val schemaUri: String = "${SchemaIndex.BASE}/schemas/1.0.0/eupid.json"
     override val vcType: String = "EuPid2023"
-    override val isoNamespace: String = "eu.europa.ec.eudiw.pid.1"
-    override val isoDocType: String = "eu.europa.ec.eudiw.pid.1"
+    override val isoNamespace: String = "eu.europa.ec.eudi.pid.1"
+    override val isoDocType: String = "eu.europa.ec.eudi.pid.1"
+    override val sdJwtType: String = "urn:eu.europa.ec.eudi:pid:1"
     override val claimNames: Collection<String> = listOf(
         Attributes.FAMILY_NAME,
         Attributes.GIVEN_NAME,

--- a/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/Initializer.kt
+++ b/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/Initializer.kt
@@ -21,14 +21,12 @@ object Initializer {
      */
     fun initWithVcLib() {
         LibraryInitializer.registerExtensionLibrary(
-            LibraryInitializer.ExtensionLibraryInfo(
-                credentialScheme = EuPidScheme,
-                serializersModule = SerializersModule {
-                    polymorphic(CredentialSubject::class) {
-                        subclass(EuPidCredential::class)
-                    }
-                },
-            )
+            credentialScheme = EuPidScheme,
+            serializersModule = SerializersModule {
+                polymorphic(CredentialSubject::class) {
+                    subclass(EuPidCredential::class)
+                }
+            }
         )
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,5 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
 
-artifactVersion = 2.0.3
+artifactVersion = 2.1.0-SNAPSHOT
 jdk.version=17

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,5 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
 
-artifactVersion = 2.1.0-SNAPSHOT
+artifactVersion = 2.1.0
 jdk.version=17

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,5 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
 
-artifactVersion = 2.1.0
+artifactVersion = 2.1.1
 jdk.version=17


### PR DESCRIPTION
Fix required claim names in `EuPidScheme` to contain `age_over_18` and `issuing_country`

Fixes #3 