### PR TITLE
Deprecate SD-JWT names

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,16 @@ These are implemented for ISO:
 - `given_name`
 - `birth_date`
 - `age_over_12`
+- `age_over_13`
 - `age_over_14`
 - `age_over_16`
 - `age_over_18`
 - `age_over_21`
+- `age_over_25`
+- `age_over_60`
+- `age_over_62`
+- `age_over_65`
+- `age_over_68`
 - `age_in_years`
 - `age_birth_year`
 - `family_name_birth`
@@ -48,6 +54,7 @@ These are implemented for ISO:
 - `issuing_jurisdiction`
 - `personal_administrative_number`
 - `portrait`
+- `portrait_capture_date`
 - `email_address`
 - `mobile_phone_number`
 - `trust_anchor`
@@ -57,6 +64,7 @@ These are implemented for ISO:
 
 Release 3.0.1:
  - Deprecate SD-JWT claim name mapping introduced in 2.3.0, please migrate to `at.asitplus.wallet:eupidcredential-sdjwt`, see <https://github.com/a-sit-plus/eu-pid-credential-sdjwt/>
+ - Add additional claims `age_over_13`, `age_over_25`, `age_over_60`, `age_over_62`, `age_over_65`, `age_over_68`, `portrait_capture_date`
 
 Release 3.0.0:
  - Update to ARF 1.5.0, deprecating removed claims, adding new claims, changing `nationality` from single element to collection

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 ![Java](https://img.shields.io/badge/java-17-blue.svg?logo=OPENJDK)
 [![Maven Central](https://img.shields.io/maven-central/v/at.asitplus.wallet/eupidcredential)](https://mvnrepository.com/artifact/at.asitplus.wallet/eupidcredential/)
 
-Use data provided by EU Wallets as a W3C VC, SD-JWT, or ISO 18013-5 credential, with the help of [VC-K](https://github.com/a-sit-plus/vck).
+Use data provided by EU Wallets as a W3C VC, SD-JWT (prior to ARF 1.8.0), or ISO 18013-5 credential, with the help of [VC-K](https://github.com/a-sit-plus/vck).
 
-Be sure to call `at.asitplus.wallet.eupid.Initializer.initWithVCK` first thing in your application.
+Be sure to call `at.asitplus.wallet.eupid.Initializer.initWithVCK()` first thing in your application.
 
 See [ARF PID Rulebook](https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/blob/main/docs/annexes/annex-3/annex-3.01-pid-rulebook.md) for a list of attributes.
 
@@ -53,46 +53,10 @@ These are implemented for ISO:
 - `trust_anchor`
 - `location_status`
 
-These are implemented for SD-JWT:
-- `family_name`
-- `given_name`
-- `birthdate`
-- `age_equal_or_over.12`
-- `age_equal_or_over.14`
-- `age_equal_or_over.16`
-- `age_equal_or_over.18`
-- `age_equal_or_over.21`
-- `age_in_years`
-- `age_birth_year`
-- `birth_family_name`
-- `birth_given_name`
-- `place_of_birth.locality`
-- `place_of_birth.country` (removed in ARF 1.5.0)
-- `place_of_birth.region` (removed in ARF 1.5.0)
-- `address.formatted`
-- `address.country`
-- `address.region`
-- `address.locality`
-- `address.postal_code`
-- `address.street_address`
-- `address.house_number`
-- `gender`
-- `nationalities`
-- `iat`
-- `exp`
-- `issuing_authority`
-- `document_number`
-- `administrative_number` (removed in ARF 1.5.0)
-- `issuing_country`
-- `issuing_jurisdiction`
-- `personal_administrative_number`
-- `portrait`
-- `email`
-- `phone_number`
-- `trust_anchor`
-- `location_status`
-
 ## Changelog
+
+Release 3.0.1:
+ - Deprecate SD-JWT claim name mapping introduced in 2.3.0, please migrate to `at.asitplus.wallet:eupidcredential-sdjwt`, see <https://github.com/a-sit-plus/eu-pid-credential-sdjwt/>
 
 Release 3.0.0:
  - Update to ARF 1.5.0, deprecating removed claims, adding new claims, changing `nationality` from single element to collection

--- a/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidCredential.kt
+++ b/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidCredential.kt
@@ -40,6 +40,10 @@ data class EuPidCredential(
     @SerialName(Attributes.AGE_OVER_12)
     val ageOver12: Boolean? = null,
 
+    /** Additional current age attestations: Attesting whether the PID User is currently over 13 years old. */
+    @SerialName(Attributes.AGE_OVER_13)
+    val ageOver13: Boolean? = null,
+
     /** Additional current age attestations: Attesting whether the PID User is currently over 14 years old. */
     @SerialName(Attributes.AGE_OVER_14)
     val ageOver14: Boolean? = null,
@@ -55,6 +59,26 @@ data class EuPidCredential(
     /** Additional current age attestations: Attesting whether the PID User is currently over 21 years old. */
     @SerialName(Attributes.AGE_OVER_21)
     val ageOver21: Boolean? = null,
+
+    /** Additional current age attestations: Attesting whether the PID User is currently over 25 years old. */
+    @SerialName(Attributes.AGE_OVER_25)
+    val ageOver25: Boolean? = null,
+
+    /** Additional current age attestations: Attesting whether the PID User is currently over 60 years old. */
+    @SerialName(Attributes.AGE_OVER_60)
+    val ageOver60: Boolean? = null,
+
+    /** Additional current age attestations: Attesting whether the PID User is currently over 62 years old. */
+    @SerialName(Attributes.AGE_OVER_62)
+    val ageOver62: Boolean? = null,
+
+    /** Additional current age attestations: Attesting whether the PID User is currently over 65 years old. */
+    @SerialName(Attributes.AGE_OVER_65)
+    val ageOver65: Boolean? = null,
+
+    /** Additional current age attestations: Attesting whether the PID User is currently over 68 years old. */
+    @SerialName(Attributes.AGE_OVER_68)
+    val ageOver68: Boolean? = null,
 
     /** The current age of the User to whom the person identification data relates in years. */
     @SerialName(Attributes.AGE_IN_YEARS)

--- a/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidCredentialSdJwt.kt
+++ b/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidCredentialSdJwt.kt
@@ -11,11 +11,9 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 
-/**
- * PID according to [EU PID Rule Book, v1.5.0 from February 2025](https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/blob/main/docs/annexes/annex-3/annex-3.01-pid-rulebook.md)
- * with mapping of claim names according to [PR #160](https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/pull/160)
- **/
+/** PID with SD-JWT names will be represented in a separate artifact. **/
 @Serializable
+@Deprecated("Migrate to separate artifact")
 data class EuPidCredentialSdJwt(
     /** Current last name(s) or surname(s) of the user to whom the person identification data relates. */
     @SerialName(SdJwtAttributes.FAMILY_NAME)
@@ -135,7 +133,7 @@ data class EuPidCredentialSdJwt(
     @SerialName(SdJwtAttributes.LOCATION_STATUS)
     val locationStatus: String? = null,
 
-) {
+    ) {
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -232,6 +230,8 @@ data class EuPidCredentialSdJwt(
     }
 }
 
+/** PID with SD-JWT names will be represented in a separate artifact. **/
+@Deprecated("Migrate to separate artifact")
 @Serializable
 data class AgeEqualOrOverSdJwt(
     /** Additional current age attestations: Attesting whether the PID User is currently over 12 years old. */
@@ -255,6 +255,8 @@ data class AgeEqualOrOverSdJwt(
     val equalOrOver21: Boolean? = null,
 )
 
+/** PID with SD-JWT names will be represented in a separate artifact. **/
+@Deprecated("Migrate to separate artifact")
 @Serializable
 data class PlaceOfBirthSdJwt(
     /** The country where the PID User was born, as an Alpha-2 country code as specified in ISO 3166-1. */
@@ -274,6 +276,8 @@ data class PlaceOfBirthSdJwt(
     val locality: String? = null,
 )
 
+/** PID with SD-JWT names will be represented in a separate artifact. **/
+@Deprecated("Migrate to separate artifact")
 @Serializable
 data class AddressSdJwt(
     /**

--- a/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidCredentialSdJwt.kt
+++ b/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidCredentialSdJwt.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
 
 /** PID with SD-JWT names will be represented in a separate artifact. **/
 @Serializable
-@Deprecated("Migrate to separate artifact")
+@Deprecated("Migrate to separate artifact, see https://github.com/a-sit-plus/eu-pid-credential-sdjwt/")
 data class EuPidCredentialSdJwt(
     /** Current last name(s) or surname(s) of the user to whom the person identification data relates. */
     @SerialName(SdJwtAttributes.FAMILY_NAME)
@@ -231,7 +231,7 @@ data class EuPidCredentialSdJwt(
 }
 
 /** PID with SD-JWT names will be represented in a separate artifact. **/
-@Deprecated("Migrate to separate artifact")
+@Deprecated("Migrate to separate artifact, see https://github.com/a-sit-plus/eu-pid-credential-sdjwt/")
 @Serializable
 data class AgeEqualOrOverSdJwt(
     /** Additional current age attestations: Attesting whether the PID User is currently over 12 years old. */
@@ -256,7 +256,7 @@ data class AgeEqualOrOverSdJwt(
 )
 
 /** PID with SD-JWT names will be represented in a separate artifact. **/
-@Deprecated("Migrate to separate artifact")
+@Deprecated("Migrate to separate artifact, see https://github.com/a-sit-plus/eu-pid-credential-sdjwt/")
 @Serializable
 data class PlaceOfBirthSdJwt(
     /** The country where the PID User was born, as an Alpha-2 country code as specified in ISO 3166-1. */
@@ -277,7 +277,7 @@ data class PlaceOfBirthSdJwt(
 )
 
 /** PID with SD-JWT names will be represented in a separate artifact. **/
-@Deprecated("Migrate to separate artifact")
+@Deprecated("Migrate to separate artifact, see https://github.com/a-sit-plus/eu-pid-credential-sdjwt/")
 @Serializable
 data class AddressSdJwt(
     /**

--- a/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidScheme.kt
+++ b/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidScheme.kt
@@ -253,7 +253,7 @@ object EuPidScheme : ConstantIndex.CredentialScheme {
     /**
      * Maps entries of [Attributes] to entries of [SdJwtAttributes]
      */
-    @Deprecated("Migrate to separate artifact")
+    @Deprecated("Migrate to separate artifact, see https://github.com/a-sit-plus/eu-pid-credential-sdjwt/")
     val mapIsoToSdJwtAttributes = mapOf(
         Attributes.FAMILY_NAME to SdJwtAttributes.FAMILY_NAME,
         Attributes.GIVEN_NAME to SdJwtAttributes.GIVEN_NAME,
@@ -299,7 +299,7 @@ object EuPidScheme : ConstantIndex.CredentialScheme {
      * Maps entries of [Attributes] to entries of [SdJwtAttributes],
      * but only those attribute names that change (from ISO to SD-JWT)
      */
-    @Deprecated("Migrate to separate artifact")
+    @Deprecated("Migrate to separate artifact, see https://github.com/a-sit-plus/eu-pid-credential-sdjwt/")
     val mapIsoToSdJwtAttributesDifferences = mapOf(
         Attributes.BIRTH_DATE to SdJwtAttributes.BIRTH_DATE,
         Attributes.AGE_OVER_12 to SdJwtAttributes.AGE_EQUAL_OR_OVER_12,
@@ -329,7 +329,7 @@ object EuPidScheme : ConstantIndex.CredentialScheme {
     )
 
     /** PID with SD-JWT names will be represented in a separate artifact. **/
-    @Deprecated("Migrate to separate artifact")
+    @Deprecated("Migrate to separate artifact, see https://github.com/a-sit-plus/eu-pid-credential-sdjwt/")
     object SdJwtAttributes {
         /** Current last name(s) or surname(s) of the user to whom the person identification data relates. */
         const val FAMILY_NAME = "family_name"

--- a/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidScheme.kt
+++ b/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidScheme.kt
@@ -23,10 +23,16 @@ object EuPidScheme : ConstantIndex.CredentialScheme {
         Attributes.BIRTH_DATE,
 
         Attributes.AGE_OVER_12,
+        Attributes.AGE_OVER_13,
         Attributes.AGE_OVER_14,
         Attributes.AGE_OVER_16,
         Attributes.AGE_OVER_18,
         Attributes.AGE_OVER_21,
+        Attributes.AGE_OVER_25,
+        Attributes.AGE_OVER_60,
+        Attributes.AGE_OVER_62,
+        Attributes.AGE_OVER_65,
+        Attributes.AGE_OVER_68,
         Attributes.AGE_IN_YEARS,
         Attributes.AGE_BIRTH_YEAR,
         Attributes.FAMILY_NAME_BIRTH,
@@ -87,6 +93,9 @@ object EuPidScheme : ConstantIndex.CredentialScheme {
         /** Additional current age attestations: Attesting whether the PID User is currently over 12 years old. */
         const val AGE_OVER_12 = "age_over_12"
 
+        /** Additional current age attestations: Attesting whether the PID User is currently over 13 years old. */
+        const val AGE_OVER_13 = "age_over_13"
+
         /** Additional current age attestations: Attesting whether the PID User is currently over 14 years old. */
         const val AGE_OVER_14 = "age_over_14"
 
@@ -98,6 +107,21 @@ object EuPidScheme : ConstantIndex.CredentialScheme {
 
         /** Additional current age attestations: Attesting whether the PID User is currently over 21 years old. */
         const val AGE_OVER_21 = "age_over_21"
+
+        /** Additional current age attestations: Attesting whether the PID User is currently over 25 years old. */
+        const val AGE_OVER_25 = "age_over_25"
+
+        /** Additional current age attestations: Attesting whether the PID User is currently over 60 years old. */
+        const val AGE_OVER_60 = "age_over_60"
+
+        /** Additional current age attestations: Attesting whether the PID User is currently over 62 years old. */
+        const val AGE_OVER_62 = "age_over_62"
+
+        /** Additional current age attestations: Attesting whether the PID User is currently over 65 years old. */
+        const val AGE_OVER_65 = "age_over_65"
+
+        /** Additional current age attestations: Attesting whether the PID User is currently over 68 years old. */
+        const val AGE_OVER_68 = "age_over_68"
 
         /** The current age of the User to whom the person identification data relates in years.. */
         const val AGE_IN_YEARS = "age_in_years"
@@ -208,6 +232,9 @@ object EuPidScheme : ConstantIndex.CredentialScheme {
 
         /** Facial image of the wallet user compliant with ISO 19794-5 or ISO 39794 specifications. */
         const val PORTRAIT = "portrait"
+
+        /** Date when portrait was taken. */
+        const val PORTRAIT_CAPTURE_DATE = "portrait_capture_date"
 
         /** Electronic mail address of the user to whom the person identification data relates, in conformance with [RFC 5322]. */
         const val EMAIL_ADDRESS = "email_address"

--- a/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidScheme.kt
+++ b/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidScheme.kt
@@ -226,7 +226,7 @@ object EuPidScheme : ConstantIndex.CredentialScheme {
     /**
      * Maps entries of [Attributes] to entries of [SdJwtAttributes]
      */
-    @Suppress("DEPRECATION")
+    @Deprecated("Migrate to separate artifact")
     val mapIsoToSdJwtAttributes = mapOf(
         Attributes.FAMILY_NAME to SdJwtAttributes.FAMILY_NAME,
         Attributes.GIVEN_NAME to SdJwtAttributes.GIVEN_NAME,
@@ -272,7 +272,7 @@ object EuPidScheme : ConstantIndex.CredentialScheme {
      * Maps entries of [Attributes] to entries of [SdJwtAttributes],
      * but only those attribute names that change (from ISO to SD-JWT)
      */
-    @Suppress("DEPRECATION")
+    @Deprecated("Migrate to separate artifact")
     val mapIsoToSdJwtAttributesDifferences = mapOf(
         Attributes.BIRTH_DATE to SdJwtAttributes.BIRTH_DATE,
         Attributes.AGE_OVER_12 to SdJwtAttributes.AGE_EQUAL_OR_OVER_12,
@@ -301,9 +301,8 @@ object EuPidScheme : ConstantIndex.CredentialScheme {
         Attributes.MOBILE_PHONE_NUMBER to SdJwtAttributes.PHONE_NUMBER,
     )
 
-    /**
-     * Per <https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/pull/160>
-     */
+    /** PID with SD-JWT names will be represented in a separate artifact. **/
+    @Deprecated("Migrate to separate artifact")
     object SdJwtAttributes {
         /** Current last name(s) or surname(s) of the user to whom the person identification data relates. */
         const val FAMILY_NAME = "family_name"

--- a/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/Initializer.kt
+++ b/eupidcredential/src/commonMain/kotlin/at/asitplus/wallet/eupid/Initializer.kt
@@ -38,10 +38,16 @@ object Initializer {
             jsonValueEncoder = jsonValueEncoder(),
             itemValueSerializerMap = mapOf(
                 EuPidScheme.Attributes.AGE_OVER_12 to Boolean.serializer(),
+                EuPidScheme.Attributes.AGE_OVER_13 to Boolean.serializer(),
                 EuPidScheme.Attributes.AGE_OVER_14 to Boolean.serializer(),
                 EuPidScheme.Attributes.AGE_OVER_16 to Boolean.serializer(),
                 EuPidScheme.Attributes.AGE_OVER_18 to Boolean.serializer(),
                 EuPidScheme.Attributes.AGE_OVER_21 to Boolean.serializer(),
+                EuPidScheme.Attributes.AGE_OVER_25 to Boolean.serializer(),
+                EuPidScheme.Attributes.AGE_OVER_60 to Boolean.serializer(),
+                EuPidScheme.Attributes.AGE_OVER_62 to Boolean.serializer(),
+                EuPidScheme.Attributes.AGE_OVER_65 to Boolean.serializer(),
+                EuPidScheme.Attributes.AGE_OVER_68 to Boolean.serializer(),
                 EuPidScheme.Attributes.BIRTH_DATE to LocalDate.serializer(),
                 EuPidScheme.Attributes.AGE_IN_YEARS to UInt.serializer(),
                 EuPidScheme.Attributes.AGE_BIRTH_YEAR to UInt.serializer(),
@@ -51,6 +57,7 @@ object Initializer {
                 EuPidScheme.Attributes.ISSUANCE_DATE to Instant.serializer(),
                 EuPidScheme.Attributes.EXPIRY_DATE to Instant.serializer(),
                 EuPidScheme.Attributes.PORTRAIT to ByteArraySerializer(),
+                EuPidScheme.Attributes.PORTRAIT_CAPTURE_DATE to LocalDate.serializer(),
             )
         )
     }

--- a/eupidcredential/src/commonTest/kotlin/at/asitplus/wallet/eupid/IsoSerializationTest.kt
+++ b/eupidcredential/src/commonTest/kotlin/at/asitplus/wallet/eupid/IsoSerializationTest.kt
@@ -5,10 +5,16 @@ import at.asitplus.signum.indispensable.cosef.*
 import at.asitplus.wallet.eupid.EuPidScheme.Attributes.AGE_BIRTH_YEAR
 import at.asitplus.wallet.eupid.EuPidScheme.Attributes.AGE_IN_YEARS
 import at.asitplus.wallet.eupid.EuPidScheme.Attributes.AGE_OVER_12
+import at.asitplus.wallet.eupid.EuPidScheme.Attributes.AGE_OVER_13
 import at.asitplus.wallet.eupid.EuPidScheme.Attributes.AGE_OVER_14
 import at.asitplus.wallet.eupid.EuPidScheme.Attributes.AGE_OVER_16
 import at.asitplus.wallet.eupid.EuPidScheme.Attributes.AGE_OVER_18
 import at.asitplus.wallet.eupid.EuPidScheme.Attributes.AGE_OVER_21
+import at.asitplus.wallet.eupid.EuPidScheme.Attributes.AGE_OVER_25
+import at.asitplus.wallet.eupid.EuPidScheme.Attributes.AGE_OVER_60
+import at.asitplus.wallet.eupid.EuPidScheme.Attributes.AGE_OVER_62
+import at.asitplus.wallet.eupid.EuPidScheme.Attributes.AGE_OVER_65
+import at.asitplus.wallet.eupid.EuPidScheme.Attributes.AGE_OVER_68
 import at.asitplus.wallet.eupid.EuPidScheme.Attributes.BIRTH_DATE
 import at.asitplus.wallet.eupid.EuPidScheme.Attributes.BIRTH_PLACE
 import at.asitplus.wallet.eupid.EuPidScheme.Attributes.DOCUMENT_NUMBER
@@ -28,6 +34,7 @@ import at.asitplus.wallet.eupid.EuPidScheme.Attributes.LOCATION_STATUS
 import at.asitplus.wallet.eupid.EuPidScheme.Attributes.NATIONALITY
 import at.asitplus.wallet.eupid.EuPidScheme.Attributes.PERSONAL_ADMINISTRATIVE_NUMBER
 import at.asitplus.wallet.eupid.EuPidScheme.Attributes.PORTRAIT
+import at.asitplus.wallet.eupid.EuPidScheme.Attributes.PORTRAIT_CAPTURE_DATE
 import at.asitplus.wallet.eupid.EuPidScheme.Attributes.RESIDENT_ADDRESS
 import at.asitplus.wallet.eupid.EuPidScheme.Attributes.RESIDENT_CITY
 import at.asitplus.wallet.eupid.EuPidScheme.Attributes.RESIDENT_COUNTRY
@@ -107,10 +114,16 @@ private fun dataMap(): Map<String, Any> = mapOf(
     GIVEN_NAME to randomString(),
     BIRTH_DATE to randomLocalDate(),
     AGE_OVER_12 to Random.nextBoolean(),
+    AGE_OVER_13 to Random.nextBoolean(),
     AGE_OVER_14 to Random.nextBoolean(),
     AGE_OVER_16 to Random.nextBoolean(),
     AGE_OVER_18 to Random.nextBoolean(),
     AGE_OVER_21 to Random.nextBoolean(),
+    AGE_OVER_25 to Random.nextBoolean(),
+    AGE_OVER_60 to Random.nextBoolean(),
+    AGE_OVER_62 to Random.nextBoolean(),
+    AGE_OVER_65 to Random.nextBoolean(),
+    AGE_OVER_68 to Random.nextBoolean(),
     AGE_IN_YEARS to Random.nextUInt(1u, 99u),
     AGE_BIRTH_YEAR to Random.nextUInt(1900u, 2100u),
     FAMILY_NAME_BIRTH to randomString(),
@@ -133,6 +146,7 @@ private fun dataMap(): Map<String, Any> = mapOf(
     ISSUING_JURISDICTION to randomString(),
     PERSONAL_ADMINISTRATIVE_NUMBER to randomString(),
     PORTRAIT to Random.nextBytes(32),
+    PORTRAIT_CAPTURE_DATE to randomLocalDate(),
     EMAIL_ADDRESS to randomString(),
     MOBILE_PHONE_NUMBER to "+${randomString()}",
     TRUST_ANCHOR to randomString(),


### PR DESCRIPTION
Deprecate SD-JWT claim, as this will be covered by https://github.com/a-sit-plus/eu-pid-credential-sdjwt/ due to a changed `vct`